### PR TITLE
Remove legacy

### DIFF
--- a/dummy_LSD_script.sh
+++ b/dummy_LSD_script.sh
@@ -104,7 +104,7 @@ do
             $PROC_FOLDER'csa_sharp_r'$RATIO'.nii.gz' \
             $PROC_FOLDER'csa_sharp_r'$RATIO'_norm.nii.gz'
 
-    # Non linear peak extraction # this is done on LEGACY SH, probably wrong
+    # Non linear peak extraction
     sh2peaks $PROC_FOLDER'csa_sharp_r'$RATIO'_norm.nii.gz' \
              $PROC_FOLDER'csa_sharp_r'$RATIO'_norm_peakext.nii.gz' \
              -num 10 \

--- a/lsd/_sharpen_parallel.py
+++ b/lsd/_sharpen_parallel.py
@@ -82,7 +82,7 @@ def odf_sh_to_sharp_parallel(odfs_sh, sphere, mask=None, basis=None, ratio=3 / 1
     r, theta, phi = cart2sphere(sphere.x, sphere.y, sphere.z)
     real_sym_sh = sph_harm_lookup[basis]
 
-    B_reg, m, n = real_sym_sh(sh_order, theta, phi) # this is LEGACY
+    B_reg, m, n = real_sym_sh(sh_order, theta, phi, legacy=False)
     R, P = forward_sdt_deconv_mat(ratio, n, r2_term=r2_term)
 
     # scale lambda to account for differences in the number of

--- a/lsd/fit_csa.py
+++ b/lsd/fit_csa.py
@@ -73,7 +73,7 @@ def main(dwipath, bvalpath, bvecpath, maskpath, outputpath, NCORE=1, tau=1e-5, l
 	print('Elapsed time = {:.2f} s'.format(end_time - start_time))
 
 	start_time = time()
-	tournier_sh = convert_sh_basis(csa_fit.shm_coeff, sphere_conv, input_basis='descoteaux07', nbr_processes=NCORE) # convert from LEGACY to LEGACY
+	tournier_sh = convert_sh_basis(csa_fit.shm_coeff, sphere_conv, input_basis='descoteaux07', input_legacy=True, output_legacy=False, nbr_processes=NCORE) # convert from LEGACY to Normal
 	nib.Nifti1Image(tournier_sh, affine).to_filename(outputpath)
 	end_time = time()
 	print('Elapsed time (conversion({} cores)) = {:.2f} s'.format(NCORE, end_time - start_time))

--- a/lsd/fit_csa.py
+++ b/lsd/fit_csa.py
@@ -56,7 +56,7 @@ def main(dwipath, bvalpath, bvecpath, maskpath, outputpath, NCORE=1, tau=1e-5, l
 	# print('This script assumes the first volume is a brain mask')
 	# mask = data[..., 0].astype(np.bool)
 
-	mask = nib.load(maskpath).get_fdata().astype(np.bool)
+	mask = nib.load(maskpath).get_fdata().astype(bool)
 
 
 	# CSA model

--- a/lsd/normalize_data.py
+++ b/lsd/normalize_data.py
@@ -94,7 +94,7 @@ def main():
         data_norm = np.clip(mask[..., None] * (data[..., diff_mask] / data_b0_mean[..., None]), 0, 1)
         np.seterr(**old_settings)
         # Concatenate mask as fake normalized b0
-        data_norm = np.concatenate((mask.astype(np.float)[...,None], data_norm), axis=3)
+        data_norm = np.concatenate((mask.astype(np.float32)[...,None], data_norm), axis=3)
 
 
         # Clean Data from unwanted values

--- a/lsd/sh_odf_normalize.py
+++ b/lsd/sh_odf_normalize.py
@@ -17,7 +17,7 @@ def main(sh_fname, sh_norm_fname):
 
     # sphere = get_sphere('repulsion724')
     sphere = get_sphere('repulsion100')
-    B, m, n = real_sh_tournier(lmax, sphere.theta, sphere.phi) # this is LEGACY
+    B, m, n = real_sh_tournier(lmax, sphere.theta, sphere.phi, legacy=False)
 
 
     sf_maximum = np.zeros(sh.shape[:3])
@@ -38,7 +38,7 @@ def main(sh_fname, sh_norm_fname):
     end_time = time()
     print('Elapsed time (sh normalization) = {:.2f} s'.format(end_time - start_time))
 
-    nib.Nifti1Image(sh_maxnorm, affine).to_filename(sh_norm_fname) # this is LEGACY
+    nib.Nifti1Image(sh_maxnorm, affine).to_filename(sh_norm_fname)
 
 
 if __name__ == "__main__":

--- a/lsd/sharpen_sh_parallel.py
+++ b/lsd/sharpen_sh_parallel.py
@@ -9,7 +9,7 @@ from dipy.data import get_sphere
 from dipy.reconst.csdeconv import odf_sh_to_sharp
 from dipy.reconst.shm import calculate_max_order
 
-from shconv import convert_sh_basis
+# from shconv import convert_sh_basis
 from _sharpen_parallel import odf_sh_to_sharp_parallel
 
 
@@ -55,7 +55,7 @@ def main():
     NCORE = args.cores
 
     sh_img = nib.load(args.sh_fname)
-    sh = sh_img.get_fdata() # this image is in SH tournier LEGACY
+    sh = sh_img.get_fdata()
     affine = sh_img.affine
 
     if args.mask is None:

--- a/lsd/shconv.py
+++ b/lsd/shconv.py
@@ -17,7 +17,7 @@ def convert_sh_basis_parallel(args):
     return chunk_id, sh
 
 def convert_sh_basis(shm_coeff, sphere, mask=None,
-                     input_basis='descoteaux07', nbr_processes=None):
+                     input_basis='descoteaux07', input_legacy=False, output_legacy=False, nbr_processes=None):
     """Converts spherical harmonic coefficients between two bases
     Parameters
     ----------
@@ -43,8 +43,8 @@ def convert_sh_basis(shm_coeff, sphere, mask=None,
     output_basis = 'descoteaux07' if input_basis == 'tournier07' else 'tournier07'
 
     sh_order = order_from_ncoef(shm_coeff.shape[-1])
-    B_in, _ = sh_to_sf_matrix(sphere, sh_order, input_basis) # default LEGACY
-    _, invB_out = sh_to_sf_matrix(sphere, sh_order, output_basis) # default LEGACY
+    B_in, _ = sh_to_sf_matrix(sphere, sh_order, input_basis, legacy=input_legacy)
+    _, invB_out = sh_to_sf_matrix(sphere, sh_order, output_basis, legacy=output_legacy)
 
     data_shape = shm_coeff.shape
     if mask is None:


### PR DESCRIPTION
Fixes legacy vs normal SH basis.
- change shconv to allow to choose legacy or not for input and for output basis separately
- CSA uses legacy basis internally, so we convert the output to normal
- make sure to use legacy=False everywhere (legacy is Dipy default for the matrix building function)
- modified odf sharpen to use normal internally